### PR TITLE
Add evofr package for forecasting work

### DIFF
--- a/src/recipe.yaml
+++ b/src/recipe.yaml
@@ -40,6 +40,7 @@ requirements:
     #
     - augur
     - auspice
+    - evofr
     - nextalign
     - nextclade
     - nextstrain-cli


### PR DESCRIPTION
Related-to: <https://github.com/nextstrain/docker-base/pull/104>

### Testing

This will fail CI until https://github.com/bioconda/bioconda-recipes/pull/37854 is merged (or an `evofr` Conda package is otherwise available).

However, I tested this branch locally by downloading and resolving using the artifacts from that PR. After download and extraction, I temporarily modified this repo's `.condarc` for testing:

```diff
diff --git a/.condarc b/.condarc
index ca52847..186994a 100644
--- a/.condarc
+++ b/.condarc
@@ -1,4 +1,5 @@
 channels:
   - conda-forge
   - bioconda
+  - file:///home/tom/Downloads/LinuxArtifacts/packages/
 channel_priority: strict
```

and then ran `./devel/build`.

- [x] Locally builds
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
