### PR TITLE
Add reassurance that ./devel/setup doesn't screw you

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ First, setup a Conda environment for development in `.dev-env/` so that
 
 You only need to do this once, or whenever you want to refresh your development
 environment.  Either [Micromamba][], [Mamba][], or [Conda][] must be available
-for setup to succeed.
+for setup to succeed. You do not need to create a new environment yourself,
+the script automatically sets everything up without interfering with your
+existing environments.
 
 [Micromamba]: https://mamba.readthedocs.io/page/user_guide/micromamba.html
 [Mamba]: https://mamba.readthedocs.io


### PR DESCRIPTION
Having non-Nextstrain scripts mess up my conda environments in the past, I'm always careful about running things in existing environments - or even base.

In this case, all is good, no need to create an environment to be safe, so I just wanted to make this explicit.