### PR TITLE
fix: macos compat, use date -u instead of --utc

### DIFF
--- a/devel/generate-version
+++ b/devel/generate-version
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -euo pipefail
-date --utc +%Y%m%dT%H%M%SZ
+date -u +%Y%m%dT%H%M%SZ


### PR DESCRIPTION
### Description of proposed changes

Resolves #9 

macos seems to use the bsd `date` CLI rather than gnu `date`.

BSD doesn't have the long option `--utc`, but the short one. Gnu date doesn't seem to care, is fine with both, so this seems a simple compatibility fix.

This also seems to resolve #11 