### PR TITLE
Pin iqtree>=2 and remove problematic pangolin/pangolearn

### DIFF
--- a/src/recipe.yaml
+++ b/src/recipe.yaml
@@ -3,7 +3,7 @@ package:
   version: "{{ environ['VERSION'] }}"
 
 build:
-  number: 1
+  number: 0
   #
   # XXX TODO: If Boa ever supports conda-build's "pin_depends: strict" here¹, I
   # think it could replace our entire two-pass build process!  Unfortunately,
@@ -38,12 +38,12 @@ requirements:
     # separate packages (e.g. nextalign1 and nextalign2).
     # XXX TODO: Include fauna?
     #
-    - augur >=18
-    - auspice >=2.40
+    - augur
+    - auspice
     - evofr
     - nextalign
     - nextclade
-    - nextstrain-cli >=5
+    - nextstrain-cli
 
     #
     # Third-party

--- a/src/recipe.yaml
+++ b/src/recipe.yaml
@@ -38,12 +38,12 @@ requirements:
     # separate packages (e.g. nextalign1 and nextalign2).
     # XXX TODO: Include fauna?
     #
-    - augur
-    - auspice
+    - augur >=18
+    - auspice >=2.40
     - evofr
     - nextalign
     - nextclade
-    - nextstrain-cli
+    - nextstrain-cli >=5
 
     #
     # Third-party
@@ -67,9 +67,8 @@ requirements:
     - git
     - google-cloud-storage
     - gzip
+    - iqtree >=2
     - jq
-    - pangolearn
-    - pangolin
     - perl
     - ruby
     - seqkit


### PR DESCRIPTION
### Description of proposed changes
pangolin and pangolearn have some tricky dependency pins that create issues. This is a known problem.

As a result, I set up separate environments for pangolin/pangolearn/usher, different from the rest of the stack.

pangolin/pangolearn is not used by any Nextstrain workflows as I'm aware, so we don't need to include them. Nextclade does the job just fine. Pangolearn now seems to require so much memory that it's not runnable on normal consumer hardware anyways (>32GB RAM).

Hence I propose to remove pangolin/pangolearn. I also pin iqtree >=2 and add some version requirements for augur/auspice/nextstrain-cli to save us from accidental downgrades when adding a new package.

Resolves #7 