### PR TITLE
Squash noisy CI warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
     name: build and test (os=${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: mamba-org/provision-with-micromamba@v13
+      - uses: mamba-org/provision-with-micromamba@v14
         with:
           environment-file: false
 
@@ -86,7 +86,7 @@ jobs:
       - build-and-test
     runs-on: ubuntu-latest
     steps:
-      - uses: mamba-org/provision-with-micromamba@v13
+      - uses: mamba-org/provision-with-micromamba@v14
         with:
           environment-file: false
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   generate-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - id: set-version
@@ -29,8 +29,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
-          - macos-latest
+          - ubuntu-22.04
+          - macos-12
 
     name: build and test (os=${{ matrix.os }})
     runs-on: ${{ matrix.os }}
@@ -84,7 +84,7 @@ jobs:
     needs:
       - generate-version
       - build-and-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: mamba-org/provision-with-micromamba@v14
         with:


### PR DESCRIPTION
Squashes noisy warnings shown on CI workflow summary pages.

See commit messages for details.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass without warnings

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
