### PR TITLE
dev: Set CONDA_SUBDIR during build, unless it's already set

### DIFF
--- a/devel/build
+++ b/devel/build
@@ -11,6 +11,12 @@ main() {
     export PATH="$env/bin:$PATH"
     export VERSION="${VERSION:-$(./devel/generate-version)}"
 
+    # Set CONDA_SUBDIR unless it's already set.  This helps macOS users on
+    # arm64 chips use and produce osx-64 Conda packages instead of osx-arm64
+    # packages (which we don't yet support).
+    CONDA_SUBDIR="${CONDA_SUBDIR:-$(./devel/conda-subdir)}"
+    export CONDA_SUBDIR
+
     clean
     build src
     lock


### PR DESCRIPTION
This helps macOS users on arm64 chips use and produce osx-64 Conda packages instead of osx-arm64 packages (which we don't yet support).

Resolves <https://github.com/nextstrain/conda-base/issues/10>.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Overriding `CONDA_SUBDIR` manually works
- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
