### PR TITLE
devel/setup: install anaconda-client from conda-forge

### DIFF
--- a/devel/setup
+++ b/devel/setup
@@ -18,6 +18,7 @@ remove() {
 
 create() {
     local -a pkgs=(
+        anaconda-client
         boa
 
         # for manipulating recipe.yaml with jq
@@ -43,17 +44,7 @@ create() {
         --prefix "$env" \
         --override-channels \
         --channel conda-forge \
-        "${pkgs[@]}" python=3.10
-
-    # conda-forge includes a too-old version of anaconda-client, so install it
-    # (and only it) from the default channels.
-    log "Installing anaconda-client from default channels"
-    conda-ish install \
-        --yes \
-        --prefix "$env" \
-        --override-channels \
-        --channel defaults \
-        anaconda-client
+        "${pkgs[@]}"
 }
 
 conda-ish() {


### PR DESCRIPTION
### Description of proposed changes

Instead of installing anaconda-client separately from the default channel, install with other packages from conda-forge.

Previous we were installing from default because the version on conda-forge was really old. Since then, the latest version of anaconda-client has been uploaded to conda-forge.

The version on conda-forge is not limited to Python <= 3.10, so we will not run into issues with Python 3.11.

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

An alternative to #20 

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
