### PR TITLE
Add .mambarc to speed up index download

### DIFF
--- a/.mambarc
+++ b/.mambarc
@@ -1,0 +1,1 @@
+repodata_use_zst: true


### PR DESCRIPTION
### Description of proposed changes

We download package indexes a lot. A few months ago, micromamba started supporting the download of zstd compressed files instead of gzip. Downloading an index can be sped up by ~10s.

Enabling is as simple as adding `repodata_use_zst` in the `.mambarc` (or adding an appropriate env variable). If zst file is not available, there's a fallback, so this shouldn't break anything.

In my tests, this seems to reduce build times by ~20%.

Compare:
- with zst (this PR): https://github.com/nextstrain/conda-base/actions/runs/4981847694
- without zst (status quo): https://github.com/nextstrain/conda-base/actions/runs/4981414616

If this works well, we could try to add this env variable to any workflow that sets up micromamba.
