### PR TITLE
devel/setup: Pin urllib3<2

### DIFF
--- a/devel/setup
+++ b/devel/setup
@@ -36,6 +36,9 @@ create() {
         csv-diff
         curl
         wget
+
+        # Temporary pin until anaconda-client fixes dependency upstream
+        "urllib3<2"
     )
 
     log "Creating new env with packages: ${pkgs[*]}"


### PR DESCRIPTION
### Description of proposed changes

Fixes https://github.com/nextstrain/conda-base/issues/30

We can remove the pin after `anaconda-client` fixes their dependency upstream.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [x] Verified locally that urllib3 v1.26.15 gets installed.  

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
