### PR TITLE
Download latest main

### DIFF
--- a/devel/download-latest
+++ b/devel/download-latest
@@ -11,10 +11,7 @@ wget "$(
     curl -fsSL https://api.anaconda.org/package/nextstrain/nextstrain-base/files | jq -r '
           map(select(.labels|index("main")))
         | map(select(.attrs.subdir == env.CONDA_SUBDIR))
-        | (max_by(.version) | .version) as $max_version
-        | .
-        | map(select(.version == $max_version))
-        | max_by(.attrs.build_number)
+        | max_by([.version, .attrs.build_number])
         | .download_url
         | if startswith("//") then "https:\(.)" else . end
     '

--- a/devel/download-latest
+++ b/devel/download-latest
@@ -11,7 +11,10 @@ wget "$(
     curl -fsSL https://api.anaconda.org/package/nextstrain/nextstrain-base/files | jq -r '
           map(select(.labels|index("main")))
         | map(select(.attrs.subdir == env.CONDA_SUBDIR))
-        | max_by(.version)
+        | (max_by(.version) | .version) as $max_version
+        | .
+        | map(select(.version == $max_version))
+        | max_by(.attrs.build_number)
         | .download_url
         | if startswith("//") then "https:\(.)" else . end
     '

--- a/devel/download-latest
+++ b/devel/download-latest
@@ -8,10 +8,11 @@ CONDA_SUBDIR="${CONDA_SUBDIR:-$("$repo"/devel/conda-subdir)}"
 export CONDA_SUBDIR
 
 wget "$(
-    curl -fsSL https://api.anaconda.org/release/nextstrain/nextstrain-base/latest | jq -r '
-          .distributions
+    curl -fsSL https://api.anaconda.org/package/nextstrain/nextstrain-base/files | jq -r '
+          map(select(.labels|index("main")))
         | map(select(.attrs.subdir == env.CONDA_SUBDIR))
-        | .[0].download_url
+        | max_by(.version)
+        | .download_url
         | if startswith("//") then "https:\(.)" else . end
     '
 )"


### PR DESCRIPTION
### Description of proposed changes

Updates `devel/download-latest` to pull the`main` labeled package with the max `version` and `build_number` so that our CI diffs of packages only compares against the latest `main` version. 

### Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->
Similar to changes we made in the Nextstrain CLI (https://github.com/nextstrain/cli/pull/280).

Fixes #26 

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
