### PR TITLE
dev: Switch to the new setup-micromamba action…

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,10 +38,7 @@ jobs:
     name: build and test (os=${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: mamba-org/provision-with-micromamba@v15
-        with:
-          environment-file: false
-
+      - uses: mamba-org/setup-micromamba@v1
       - uses: actions/checkout@v3
 
       - run: ./devel/setup
@@ -87,10 +84,7 @@ jobs:
       - build-and-test
     runs-on: ubuntu-22.04
     steps:
-      - uses: mamba-org/provision-with-micromamba@v15
-        with:
-          environment-file: false
-
+      - uses: mamba-org/setup-micromamba@v1
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
…since provision-with-micromamba is now deprecated as of last week.¹

We use the action merely to obtain a `micromamba` executable on the PATH—shell init, environment creation, etc. is all unnecessary for our purposes—so there's not much to the switch.

¹ <https://github.com/mamba-org/provision-with-micromamba/releases/tag/v16>

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
