### PR TITLE
Add envdir program

### DIFF
--- a/devel/build
+++ b/devel/build
@@ -41,6 +41,9 @@ build() {
 }
 
 lock() {
+    log "Copying $repo/src to $repo/locked"
+    cp -a src locked
+
     # XXX TODO: It would be extra nice to prepend channel specifiers to each
     # locked dep (e.g. conda-forge::nextstrain-cli ==x.y.z hbadcafe_0_locked).
     # Boa has that info at build time, but it doesn't seem to make it into the
@@ -48,7 +51,6 @@ lock() {
     # somehow or leverage libmamba directly to obtain it…
     #   -14 Oct 2022
     log "Updating $repo/locked/recipe.yaml"
-    mkdir -p locked
     yq \
         --yaml-roundtrip \
         --slurpfile rendered <(rendered-recipe | yaml-to-json) \

--- a/src/build.sh
+++ b/src/build.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail -x
+mkdir -p "$PREFIX"/bin
+cp -v "$SRC_DIR"/envdir "$PREFIX"/bin/envdir

--- a/src/envdir
+++ b/src/envdir
@@ -1,0 +1,84 @@
+#!/usr/bin/env perl
+# A pure-Perl port of djb's envdir <https://cr.yp.to/daemontools/envdir.html>,
+# for quick, no-thought portability (because `perl` is available ~everywhere).
+#
+# There are many copies of envdir, this is mine.
+#
+# Copied from <https://github.com/tsibley/envdir/blob/a3099699/envdir>.
+#
+# Comments quote text from https://cr.yp.to/daemontools/envdir.html
+#
+# envdir runs another program with environment modified according to files in a
+# specified directory.
+#
+use strict;
+use warnings;
+use FindBin qw< $Script >;
+
+# Interface:
+#
+#     envdir <d> <child>
+#
+# <d> is a single argument. <child> consists of one or more arguments.
+#
+my $d     = shift;
+my @child = @ARGV;
+
+fatal("usage: %s <d> <child>", $Script)
+    unless defined $d and @child;
+
+# envdir sets various environment variables as specified by files in the
+# directory named <d>. It then runs <child>.
+#
+opendir my $dh, $d
+    or fatal("cannot read <%s>: %s", $d, $!);
+
+# If <d> contains a file named s whose first line is t, envdir removes an
+# environment variable named s if one exists, and then adds an environment
+# variable named s with value t.
+#
+for my $s (readdir $dh) {
+    next if $s =~ /^[.]{1,2}$/;
+
+    # The name s must not contain =.
+    next if $s =~ /=/;
+
+    delete $ENV{$s};
+
+    # If the file s is completely empty (0 bytes long), envdir removes an
+    # environment variable named s if one exists, without adding a new
+    # variable.
+    #
+    next if -z "$d/$s";
+
+    open my $fh, "<", "$d/$s"
+        or fatal("cannot read <%s>: %s", "$d/$s", $!);
+
+    my $t = <$fh>;
+
+    close $fh
+        or fatal("cannot close <%s>: %s", "$d/$s", $!);
+
+    # Spaces and tabs at the end of t are removed.
+    $t =~ s/\s+$//;
+
+    # Nulls in t are changed to newlines in the environment variable.
+    $t =~ s/\0/\n/g;
+
+    $ENV{$s} = $t;
+}
+closedir $dh
+    or fatal("cannot close <%s>: %s", $d, $!);
+
+# envdir exits 111 if it has trouble reading <d>, if it runs out of memory for
+# environment variables, or if it cannot run <child>. Otherwise its exit code
+# is the same as that of <child>.
+#
+exec @child
+    or fatal("Failed to exec([%s]): %s", join(" ", @child), $!);
+
+sub fatal {
+    my ($msg, @rest) = @_;
+    warn sprintf($msg, @rest), "\n";
+    exit 111;
+}

--- a/src/recipe.yaml
+++ b/src/recipe.yaml
@@ -15,6 +15,9 @@ build:
   #
   #pin_depends: strict
 
+source:
+  path: .
+
 about:
   home: https://nextstrain.org
   doc_url: https://docs.nextstrain.org/


### PR DESCRIPTION
This provides an `envdir` program to our Conda runtime since our other runtimes also provide this useful program and we've felt its absence.¹

Since there's no existing Conda packaging of the Python envdir distribution² we use elsewhere or any other `envdir` program AFAICT³, the particular program provided is a port I wrote long ago⁴ and still use daily on my own machines.  It's vendored into this repository and built into the Conda packages we're already producing here.  This is a quick and low-overhead solution, and we may want to switch to a packaging of the Python envdir distribution later (particularly if we want to use the Python envdir module that distribution also provides).

Resolves <https://github.com/nextstrain/conda-base/issues/35>.

¹ <https://github.com/nextstrain/.github/pull/44#discussion_r1214650282>
² <https://pypi.org/project/envdir/>

³ I checked for both daemontools, which provides the original, and s6,
  which provides another port, as well as a general search for "envdir".

⁴ <https://github.com/tsibley/envdir>


### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Built locally successfully
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
