### PR TITLE
Exclude snakemake 7.29.0 due to bug

### DIFF
--- a/src/recipe.yaml
+++ b/src/recipe.yaml
@@ -77,7 +77,7 @@ requirements:
     - perl
     - ruby
     - seqkit
-    - snakemake
+    - snakemake !=7.29.0  # See https://github.com/snakemake/snakemake/issues/2326
     - tsv-utils
     - unzip
     - wget


### PR DESCRIPTION
See https://github.com/snakemake/snakemake/issues/2326 for bug description

This 7.29.0 bug appears to be quite impactful and we should thus exclude this version.