### PR TITLE
Add nextstrain/rsv to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,6 +131,7 @@ jobs:
           - { pathogen: monkeypox }
           - { pathogen: mumps }
           - { pathogen: ncov,            build-args: all_regions -j 2 --profile nextstrain_profiles/nextstrain-ci }
+          - { pathogen: rsv }
           - { pathogen: seasonal-flu,    build-args: --configfile profiles/ci/builds.yaml -p }
           - { pathogen: zika }
     name: test-pathogen-repo-ci (${{ matrix.pathogen }})


### PR DESCRIPTION
### Description of proposed changes

This is now possible with the addition of example data in the rsv repo¹.

¹ https://github.com/nextstrain/rsv/commit/2efc4b614385a70586f0759ab0cf4600775be187

### Testing

- [x] rsv workflow runs successfully in CI