### PR TITLE
dev: Routinely check that the latest* package is initially installable…

### DIFF
--- a/.github/workflows/installation.yaml
+++ b/.github/workflows/installation.yaml
@@ -1,0 +1,39 @@
+name: Installation
+
+on:
+  # Routinely check that the latest package is initially installable, to catch
+  # issues like <https://github.com/nextstrain/monkeypox/issues/177> earlier.
+  schedule:
+    # Every day at 17:42 UTC / 9:42 Seattle (winter) / 10:42 Seattle (summer)
+    - cron: "42 17 * * *"
+
+  workflow_dispatch:
+
+jobs:
+  # The goal here is to make sure installation continues to work successfully
+  # on a variety of OS versions.  We're _not_ testing unreleased package builds
+  # here—the packages are downloaded from our Anaconda channel—which is why
+  # this isn't part of CI.
+  #   -trs, 29 August 2022
+  test:
+    name: test (os=${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-20.04
+          - ubuntu-22.04
+          - macos-11
+          - macos-12
+
+    runs-on: ${{matrix.os}}
+    steps:
+      - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
+        with:
+          # First Nextstrain CLI version which explicitly installs the latest
+          # conda-base package version during `nextstrain setup` instead of
+          # letting Micromamba resolve the package to a potentially older
+          # version.
+          #   -trs, 9 Oct 2023
+          cli-version: ">=7.3.0.post1"
+          runtime: conda


### PR DESCRIPTION
…to catch issues like the one in monkeypox CI¹ earlier.  Since
successful installation relies on external resources out of our control,
we want to regularly test it to ensure we know when an external change
breaks it.

\* As it stands currently, this isn't strictly the _latest_ package, just
  that there's _some_ package version that's installable.  To ensure
  the former, we'd have to query the latest version (e.g. similar to
  what devel/download-latest does) and pass it into setup-nextstrain-cli
  as an input, which would then pass it to `nextstrain` in
  NEXTSTRAIN_CONDA_BASE_PACKAGE.

  Alternatively, we're likely to update `nextstrain setup conda` anyway
  to query and install the latest version itself explicitly, just like
  `nextstrain update conda` does, and so this workflow can simply wait
  for that change to happen.

Resolves <https://github.com/nextstrain/conda-base/issues/41>.

¹ e.g. <https://github.com/nextstrain/monkeypox/issues/177>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Update commit message and code commentary re: "latest"
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
