### PR TITLE
dev: Temporarily pin ruamel.yaml <0.18.0 to work around Boa's issue

### DIFF
--- a/devel/setup
+++ b/devel/setup
@@ -39,6 +39,10 @@ create() {
 
         # Temporary pin until anaconda-client fixes dependency upstream
         "urllib3<2"
+
+        # Temporary pin until boa fixes dependency upstream
+        # <https://github.com/mamba-org/boa/issues/376>
+        "ruamel.yaml<0.18.0"
     )
 
     log "Creating new env with packages: ${pkgs[*]}"


### PR DESCRIPTION
Boa uses a previously deprecated and now removed API in ruamel.yaml, safe_load().  0.18.0 was the first version with its removal.

See <https://github.com/mamba-org/boa/issues/376>.

Resolves <https://github.com/nextstrain/conda-base/issues/44>.


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
