### PR TITLE
Add nextclade3 via direct download

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail -x
 mkdir -p "$PREFIX"/bin
+
+# envdir
 cp -v "$SRC_DIR"/envdir "$PREFIX"/bin/envdir
+
+# Nextclade v3
+curl -fsSL -o "$PREFIX"/bin/nextclade3 https://github.com/nextstrain/nextclade/releases/download/3.0.0-alpha.1/nextclade-$("$SRC_DIR"/target-triple)
+chmod a+rx "$PREFIX"/bin/nextclade3

--- a/src/recipe.yaml
+++ b/src/recipe.yaml
@@ -63,6 +63,8 @@ requirements:
     #
     - awscli
     - bash
+      # Pin Biopython 1.81: https://github.com/nextstrain/augur/issues/1373
+    - biopython =1.81
     - bzip2
     - csvtk
     - curl

--- a/src/target-triple
+++ b/src/target-triple
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+# Get the target triple from uname.
+#
+set -euo pipefail
+
+kernel="$(uname -s)"
+machine="$(uname -m)"
+
+case "$kernel/$machine" in
+    Linux/x86_64)
+        echo "x86_64-unknown-linux-gnu";;
+
+    Darwin/x86_64)
+        echo "x86_64-apple-darwin";;
+
+    Darwin/arm64)
+        echo "aarch64-apple-darwin";;
+
+    *)
+        echo "unsupported kernel/machine: $kernel/$machine" >&2
+        exit 1;;
+esac


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

Nextclade v3 is not yet released in Bioconda. Add it as a direct download so that users of Nextstrain's Conda runtime can transition to using nextclade3.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

- https://github.com/nextstrain/private/issues/97

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] ~Checks pass~ Failing because of unmerged [Biopython pin](https://github.com/nextstrain/conda-base/pull/51)
- [x] test-pathogen-repo-ci (rsv) gets past the `nextclade3` step

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
