### PR TITLE
Update `nextclade3` to alpha.2

### DIFF
--- a/src/build.sh
+++ b/src/build.sh
@@ -6,5 +6,5 @@ mkdir -p "$PREFIX"/bin
 cp -v "$SRC_DIR"/envdir "$PREFIX"/bin/envdir
 
 # Nextclade v3
-curl -fsSL -o "$PREFIX"/bin/nextclade3 https://github.com/nextstrain/nextclade/releases/download/3.0.0-alpha.1/nextclade-$("$SRC_DIR"/target-triple)
+curl -fsSL -o "$PREFIX"/bin/nextclade3 https://github.com/nextstrain/nextclade/releases/download/3.0.0-alpha.2/nextclade-$("$SRC_DIR"/target-triple)
 chmod a+rx "$PREFIX"/bin/nextclade3


### PR DESCRIPTION
See https://github.com/nextstrain/nextclade/releases/tag/3.0.0-alpha.2

Parallel change for docker-base: https://github.com/nextstrain/docker-base/pull/201

