### PR TITLE
fix: pin pulp<2.8, required by snakemake

### DIFF
--- a/src/recipe.yaml
+++ b/src/recipe.yaml
@@ -77,6 +77,8 @@ requirements:
     - ncbi-datasets-cli
     - pango_aliasor
     - perl
+      # Pin pulp <2.8 for snakemake: https://github.com/snakemake/snakemake/issues/2607
+    - pulp <2.8
     - ruby
     - seqkit
     - snakemake <8


### PR DESCRIPTION
Pulp 2.8.0 breaks snakemake.
We need to pin until we upgrade snakemake to a version that is compatible with recent versions of pulp again. See https://github.com/snakemake/snakemake/issues/2607 We might need to make a similar change to docker-base
