### PR TITLE
Unpin Biopython

### DIFF
--- a/src/recipe.yaml
+++ b/src/recipe.yaml
@@ -61,8 +61,6 @@ requirements:
     #
     - awscli
     - bash
-      # Pin Biopython 1.81: https://github.com/nextstrain/augur/issues/1373
-    - biopython =1.81
     - bzip2
     - csvtk
     - curl


### PR DESCRIPTION
## Description of proposed changes

<!-- What is the goal of this pull request? What does this pull request change? -->

This reverts "Pin Biopython 1.81" (9fca5a848), which is no longer necessary as of Augur version 24.1.0.

<https://github.com/nextstrain/augur/releases/tag/24.1.0>

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

- Reverts #51

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
