### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,7 +129,7 @@ jobs:
       # XXX TODO: Test on multiple platforms (os, maybe arch) via the matrix too
       matrix:
         include:
-          - { pathogen: avian-flu,       build-args: auspice/flu_avian_h5n1_ha.json }
+          - { pathogen: avian-flu,       build-args: auspice/avian-flu_h5n1_ha.json }
           - { pathogen: ebola }
           - { pathogen: lassa }
           - { pathogen: mumps }


### PR DESCRIPTION
Mirrors the change in avian-flu's CI.

## Related issue(s)

- https://github.com/nextstrain/avian-flu/pull/12

## Checklist

- [x] avian-flu pathogen-repo-ci passes
