### PR TITLE
Set default shell

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,15 @@ on:
 
   workflow_dispatch:
 
+defaults:
+  run:
+    # This is the same as GitHub Action's `bash` keyword as of 14 May 2024:
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    #
+    # Completely spelling it out here so that GitHub can't change it out from under us
+    # and we don't have to refer to the docs to know the expected behavior.
+    shell: bash --noprofile --norc -eo pipefail {0}
+
 jobs:
   generate-version:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Description of proposed changes

Set the default shell to the same command as the GitHub Action `bash` keyword¹

Completely spelling out the bash command here so that GitHub can't change it out from under us and we don't have to refer to the docs to know the expected behavior.

¹ https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell

## Related issue(s)

- Prompted by https://github.com/nextstrain/conda-base/pull/58#discussion_r1458065631

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
