### PR TITLE
Provide GNU coreutils in the runtime

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,7 +152,7 @@ jobs:
           # - { pathogen: zika }
 
     name: test-pathogen-repo-ci (${{ matrix.pathogen }})
-    uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@master
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@v0
     with:
       repo: nextstrain/${{ matrix.pathogen }}
       build-args: ${{ matrix.build-args }}

--- a/src/recipe.yaml
+++ b/src/recipe.yaml
@@ -63,6 +63,7 @@ requirements:
     - bash
     - bzip2
     - csvtk
+    - coreutils
     - curl
     - epiweeks
     - git


### PR DESCRIPTION
They're provided in our other runtimes (almost by happenstance, as part of the underlying OS image) and having them available in all runtimes makes it much easier to write portable programs without having to deal with GNU vs. BSD differences.

Note that typically GNU coreutils would already be available in the Conda runtime on Linux (via the host system), but not the Conda runtime on macOS (unless installed separately, e.g. via Homebrew).  So explicitly including GNU coreutils here increases consistency, isolation, and portability of the runtime.

Related-to: <https://github.com/nextstrain/ingest/issues/41>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
