### PR TITLE
Add pathogen-embed as a first-party dependency

### DIFF
--- a/src/recipe.yaml
+++ b/src/recipe.yaml
@@ -45,6 +45,7 @@ requirements:
     - nextclade2
     - nextclade
     - nextstrain-cli
+    - pathogen-embed
 
     #
     # Third-party


### PR DESCRIPTION
## Description of proposed changes

Adds pathogen-embed to base image, so we can use its tools for analysis of reassortment in our influenza builds.

## Related issue(s)

https://github.com/nextstrain/docker-base/pull/221

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Tested locally on avian flu HA sequences after running `nextstrain update conda` with the recipe from this PR and confirmed that the output matches my PyPI installation of the same tools

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
