### PR TITLE
Installation: Drop macos-11

### DIFF
--- a/.github/workflows/installation.yaml
+++ b/.github/workflows/installation.yaml
@@ -23,7 +23,6 @@ jobs:
         os:
           - ubuntu-20.04
           - ubuntu-22.04
-          - macos-11
           - macos-12
           - macos-13
           - macos-14


### PR DESCRIPTION
GH Action has removed macos-11 on 28 June 2024.¹
Resolves <https://github.com/nextstrain/conda-base/issues/72>

¹ <https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/#macos-11-deprecation-and-removal>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] [Manual run of installation](https://github.com/nextstrain/conda-base/actions/runs/9749528909)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
