### PR TITLE
Add build for osx-arm64

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,8 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - macos-13
+          - macos-13 # x86_64
+          - macos-14 # arm64
 
     name: build and test (os=${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,6 +87,7 @@ jobs:
             nextstrain-base
 
       - name: Generate summary
+        continue-on-error: true
         run: |
           ./devel/download-latest
           ./devel/diff-pkgs nextstrain-base-*.conda build/locked/*/nextstrain-base-*.conda \

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To build this package locally, run:
 
 The final built package will be written to
 `build/locked/<arch>/nextstrain-base-*.conda`, where `<arch>` is a Conda
-subdir, e.g. `linux-64` or `osx-64`.
+subdir, i.e. `linux-64`, `osx-64` or `osx-arm64`.
 
 [CI][] builds store the entire `build/` and `locked/` directories as an
 artifact attached to each CI run.  You can download the artifacts to inspect

--- a/devel/build
+++ b/devel/build
@@ -11,9 +11,7 @@ main() {
     export PATH="$env/bin:$PATH"
     export VERSION="${VERSION:-$(./devel/generate-version)}"
 
-    # Set CONDA_SUBDIR unless it's already set.  This helps macOS users on
-    # arm64 chips use and produce osx-64 Conda packages instead of osx-arm64
-    # packages (which we don't yet support).
+    # Set CONDA_SUBDIR unless it's already set.
     CONDA_SUBDIR="${CONDA_SUBDIR:-$(./devel/conda-subdir)}"
     export CONDA_SUBDIR
 

--- a/devel/conda-subdir
+++ b/devel/conda-subdir
@@ -15,7 +15,7 @@ case "$kernel/$machine" in
         echo "osx-64";;
 
     Darwin/arm64)
-        echo "osx-64";;
+        echo "osx-arm64";;
 
     *)
         echo "unsupported kernel/machine: $kernel/$machine" >&2

--- a/devel/download-latest
+++ b/devel/download-latest
@@ -7,12 +7,14 @@ export PATH="$env/bin:$PATH"
 CONDA_SUBDIR="${CONDA_SUBDIR:-$("$repo"/devel/conda-subdir)}"
 export CONDA_SUBDIR
 
-wget "$(
+url="$(
     curl -fsSL https://api.anaconda.org/package/nextstrain/nextstrain-base/files | jq -r '
           map(select(.labels|index("main")))
         | map(select(.attrs.subdir == env.CONDA_SUBDIR))
+        | if length == 0 then ("error: download-latest: no packages found\n" | halt_error) else . end
         | max_by([.version, .attrs.build_number])
         | .download_url
         | if startswith("//") then "https:\(.)" else . end
     '
 )"
+wget "$url"

--- a/devel/extract-pkg-info
+++ b/devel/extract-pkg-info
@@ -22,7 +22,7 @@ main() {
     package="$1"
     file="$2"
 
-    unzip -p "$package" "info-$(basename "$package" .conda).tar.zst" \
+    7z e -so "$package" "info-$(basename "$package" .conda).tar.zst" \
         | unzstd --stdout \
         | tar --extract --to-stdout "info/$file"
 }

--- a/devel/setup
+++ b/devel/setup
@@ -25,8 +25,8 @@ create() {
         yq
 
         # for extracting files from .conda packages
+        p7zip
         tar
-        unzip
         zstd
 
         # to get gnu `date` on macOS


### PR DESCRIPTION
## Description of proposed changes

Build conda-base for osx-arm64 as well.

## Related issue(s)

Resolves #77 

## Checklist

- [x] Checks pass
- [x] Ran a draft ebola workflow locally using this environment with https://github.com/nextstrain/cli/pull/379