### PR TITLE
CI: Update test-pathogen-repo-ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -174,7 +174,10 @@ jobs:
       # XXX TODO: Test on multiple platforms (os, maybe arch) via the matrix too
       matrix:
         pathogen:
+          - dengue
+          - measles
           - mpox
+          - seasonal-cov
           - zika
 
     name: test-pathogen-repo-ci (${{ matrix.pathogen }})

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -130,12 +130,15 @@ jobs:
           LABEL: ${{ needs.generate-version.outputs.label }}
 
   # Run pathogen repo CI builds with the final packages
-  test-pathogen-repo-ci:
+  # This is running pathogen-repo-ci@v0 for pathogen repos that do not conform
+  # to the standard pathogen repo structure and is not expected to be updated.
+  # Any new pathogen repos should be added to the job using the latest version
+  # of the pathogen-repo-ci below.
+  test-pathogen-repo-ci-v0:
     needs:
       - generate-version
       - release
     strategy:
-      # XXX TODO: Test on multiple platforms (os, maybe arch) via the matrix too
       matrix:
         include:
           - { pathogen: avian-flu,       build-args: test_target }
@@ -146,16 +149,38 @@ jobs:
           - { pathogen: rsv }
           - { pathogen: seasonal-flu,    build-args: --configfile profiles/ci/builds.yaml -p }
 
-          # Disable some pathogens until pathogen-repo-ci supports custom build directories
-          # TODO: Re-enable once issue is resolved: https://github.com/nextstrain/.github/issues/63
-          # - { pathogen: mpox }
-          # - { pathogen: zika }
-
-    name: test-pathogen-repo-ci (${{ matrix.pathogen }})
+    name: test-pathogen-repo-ci@v0 (${{ matrix.pathogen }})
     uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@v0
     with:
       repo: nextstrain/${{ matrix.pathogen }}
       build-args: ${{ matrix.build-args }}
+      runtimes: |
+        - conda
+      env: |
+        NEXTSTRAIN_CONDA_CHANNEL: nextstrain/label/${{ needs.generate-version.outputs.label }}
+        NEXTSTRAIN_CONDA_BASE_PACKAGE: nextstrain-base ==${{ needs.generate-version.outputs.version }}
+      artifact-name: ${{ matrix.pathogen }}-outputs
+      continue-on-error: true
+
+  # Run pathogen repo CI builds with the final packages
+  # This is running pathogen-repo-ci@master for pathogen repos that _do_ follow
+  # standard pathogen repo structure and new pathogens should be added here
+  # to be supported for future updates such as testing on multiple platforms.
+  test-pathogen-repo-ci:
+    needs:
+      - generate-version
+      - release
+    strategy:
+      # XXX TODO: Test on multiple platforms (os, maybe arch) via the matrix too
+      matrix:
+        pathogen:
+          - mpox
+          - zika
+
+    name: test-pathogen-repo-ci (${{ matrix.pathogen }})
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-ci.yaml@master
+    with:
+      repo: nextstrain/${{ matrix.pathogen }}
       runtimes: |
         - conda
       env: |


### PR DESCRIPTION
## Description of proposed changes

Add comments to clearly show the job using pathogen-repo-ci@v0 is for pathogen repos that do not conform to the standard pathogen repo structure. Since these are tied to a old tag of the `pathogen-repo-ci`, the job should not be expected to be updated.

Any new pathogen repos should be added to the `test-pathogen-repo-ci` job which uses the latest version of `pathogen-repo-ci`.

## Related issue(s)

Prompted by https://github.com/nextstrain/conda-base/issues/83#issuecomment-2231501640
Resolves https://github.com/nextstrain/conda-base/issues/78
Related to https://github.com/nextstrain/.github/issues/84

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
