### PR TITLE
Surface installation failures with GitHub issues

### DIFF
--- a/.github/workflows/installation.yaml
+++ b/.github/workflows/installation.yaml
@@ -3,15 +3,6 @@ name: Installation
 on:
   # Routinely check that the latest package is initially installable, to catch
   # issues like <https://github.com/nextstrain/monkeypox/issues/177> earlier.
-  #
-  # Hey you!  Yes, you there.  If you update this, you'll start getting the
-  # failure notifications (e.g. via email and/or on github.com) instead of
-  # @nextstrain-bot (and thus the team) getting them.  So then, update as
-  # needed, but afterwards please log in as @nextstrain-bot, disable this
-  # workflow, and then re-enable it again.¹
-  #   -trs, 15 July 2024
-  #
-  # ¹ <https://github.com/nextstrain/conda-base/actions/workflows/installation.yaml>
   schedule:
     # Every day at 17:42 UTC / 9:42 Seattle (winter) / 10:42 Seattle (summer)
     - cron: "42 17 * * *"
@@ -47,3 +38,65 @@ jobs:
           #   -trs, 9 Oct 2023
           cli-version: ">=7.3.0.post1"
           runtime: conda
+
+  # Surface failures via GitHub issues
+  failure-reporting:
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create or close issue
+        run: |
+          # Search for issues opened by this job.
+          matching_issues=$(gh issue list \
+            --state open \
+            --author '@me' \
+            --json 'number,title' \
+            --jq 'map(select(.title == "${{ env.title }}") | .number)')
+
+          # Handle the case of multiple matching issues, even though this
+          # shouldn't happen under normal circumstances.
+          if [[ $(jq length <<<"$matching_issues") -gt 1 ]]; then
+            echo "ERROR: Multiple matching issues found:" >&2
+            for issue in $(jq -r '.[]' <<<"$matching_issues"); do
+                echo "- https://github.com/${{ github.repository }}/issues/$issue" >&2
+            done
+            echo "This must be handled manually." >&2
+            exit 1
+          fi
+
+          existing_issue=$(jq -r '.[0] | values' <<<"$matching_issues")
+
+          if [[ "${{ needs.test.result }}" == "failure" ]]; then
+            if  [[ -z "$existing_issue" ]]; then
+              echo "New failure detected. Creating issue..."
+              new_issue=$(gh issue create \
+                --title "$title" \
+                --body "$body")
+              echo "Created issue: $new_issue"
+            else
+              echo "Open issue already exists: https://github.com/${{ github.repository }}/issues/$existing_issue"
+            fi
+          fi
+
+          if [[ "${{ needs.test.result }}" == "success" ]]; then
+            if [[ -n "$existing_issue" ]]; then
+              echo "Closing issue https://github.com/${{ github.repository }}/issues/$existing_issue"
+              gh issue close "$existing_issue" \
+                --comment "Installation is successful as of https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            else
+              echo "No open issue to be closed."
+            fi
+          fi
+
+        env:
+          title: Installation failure
+          body: |
+            _Automatically created by [installation.yaml](https://github.com/${{ github.repository }}/blob/${{ github.sha }}/.github/workflows/installation.yaml)_
+
+            An installation check has failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+            This issue will be automatically closed upon the next successful run of the workflow.
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_REPO }}


### PR DESCRIPTION
## Description of proposed changes

This replace the brittle email notification setup with GitHub issues which should be more visible and actionable.

## Related issue(s)

Closes #84

## Checklist

- [x] ~Checks pass~ not applicable to these changes
- [x] Allow this repo to access org secret `GH_TOKEN_NEXTSTRAIN_BOT_REPO` (only `public_repo` is required for issue management but I figured it'd be ok to use an existing secret that has a superset of permissions)
- [x] Turn off workflow failure notifications for @nextstrain-bot

Testing done on this repo:

- [x] [Installation success with no open issue = no action](https://github.com/nextstrain/conda-base/actions/runs/10258410321/job/28381303204#step:3:54)
- [ ] Post-merge: check that an issue is opened upon installation failure if/when that happens

Testing done on personal fork repo:

- [x] [Installation failure = issue created](https://github.com/victorlin/conda-base/actions/runs/10258262362/job/28380806172#step:3:54)
    - Preview: https://github.com/victorlin/conda-base/issues/9
- [x] [Installation failure with 1 open issue = no action](https://github.com/victorlin/conda-base/actions/runs/10258293769/job/28380888632#step:3:54)
- [x] [Installation success with 2 open issues = error](https://github.com/victorlin/conda-base/actions/runs/10258312066/job/28380936584#step:3:54)
- [x] [Installation success with 1 open issue = issue closed](https://github.com/victorlin/conda-base/actions/runs/10258323369/job/28380966687#step:3:54)
- [x] [Installation success with no open issue = no action](https://github.com/victorlin/conda-base/actions/runs/10258329987/job/28380981356#step:3:54)
- [x] Other open issues are left untouched: https://github.com/victorlin/conda-base/issues/2
