### PR TITLE
Revert to previous minimum glibc version of ≥2.17 instead of ≥2.28

### DIFF
--- a/src/recipe.yaml
+++ b/src/recipe.yaml
@@ -87,3 +87,15 @@ requirements:
     - xz
     - zip
     - zstd
+
+    # Avoid a newer minimum glibc version introduced by c-ares 1.33.0¹.  This
+    # pin keeps the previous glibc requirement of ≥2.17 instead of ≥2.28.²
+    # Eventually this pin will become unworkable, but we can keep it for now.
+    #
+    # Note that using run_constrained doesn't work (at least on the face of
+    # it), potentially (?) because of our two-step build process.
+    #   -trs, 16 Sept 2024
+    #
+    # ¹ <https://github.com/conda-forge/c-ares-feedstock/pull/38>
+    # ² <https://github.com/nextstrain/conda-base/issues/92>
+    - c-ares <1.33.0


### PR DESCRIPTION
Resolves: <https://github.com/nextstrain/conda-base/issues/92>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
