### PR TITLE
Provide GNU awk, grep, sed, and tar in the runtime

### DIFF
--- a/src/recipe.yaml
+++ b/src/recipe.yaml
@@ -68,7 +68,9 @@ requirements:
     - curl
     - epiweeks
     - git
+    - gawk
     - google-cloud-storage
+    - grep
     - gzip
     - iqtree >=2
     - jq
@@ -78,9 +80,11 @@ requirements:
       # Pin pulp <2.8 for snakemake: https://github.com/snakemake/snakemake/issues/2607
     - pulp <2.8
     - ruby
+    - sed
     - seqkit
     - snakemake <8
     - sqlite
+    - tar
     - tsv-utils
     - unzip
     - wget


### PR DESCRIPTION
They're provided in our other runtimes (almost by happenstance, as part of the underlying OS image) and having them available in all runtimes makes it much easier to write portable programs without having to deal with GNU vs. BSD differences.

Note that typically these GNU programs would already be available in the Conda runtime on Linux (via the host system), but not the Conda runtime on macOS (unless installed separately, e.g. via Homebrew).  So explicitly including the GNU-flavored programs here increases consistency, isolation, and portability of the runtime.

These were ostensibly overlooked in "Provide GNU coreutils in the runtime" (a0b6609).

Related-to: <https://github.com/nextstrain/oropouche/pull/18#discussion_r1792991833>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
