### PR TITLE
Check installation workflow upon edit

### DIFF
--- a/.github/workflows/installation.yaml
+++ b/.github/workflows/installation.yaml
@@ -7,6 +7,10 @@ on:
     # Every day at 17:42 UTC / 9:42 Seattle (winter) / 10:42 Seattle (summer)
     - cron: "42 17 * * *"
 
+  pull_request:
+    paths:
+      - .github/workflows/installation.yaml
+
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/installation.yaml
+++ b/.github/workflows/installation.yaml
@@ -45,7 +45,7 @@ jobs:
 
   # Surface failures via GitHub issues
   failure-reporting:
-    if: ${{ always() }}
+    if: ${{ always() && github.ref_name == github.event.repository.default_branch }}
     runs-on: ubuntu-latest
     needs: [test]
     steps:


### PR DESCRIPTION
## Description of proposed changes

This immediately verifies that the updated workflow is still valid, rather than waiting for the next scheduled run or a manual run.

## Related issue(s)

Thought of this while working on #99.

## Checklist

- [x] Installation workflow runs in PR checks (failing for [unrelated reasons](https://github.com/nextstrain/conda-base/issues/98))
- [x] failure-reporting job is skipped in PR run
