### PR TITLE
Move failure reporting to reusable workflow

### DIFF
--- a/.github/workflows/installation.yaml
+++ b/.github/workflows/installation.yaml
@@ -43,79 +43,13 @@ jobs:
           cli-version: ">=7.3.0.post1"
           runtime: conda
 
-  # Surface failures via GitHub issues
-  failure-reporting:
+  report-failure:
     if: ${{ always() && github.ref_name == github.event.repository.default_branch }}
-    runs-on: ubuntu-latest
     needs: [test]
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set variables
-        run: |
-          echo "title='Installation failure'" >> "$GITHUB_ENV"
-
-          if [[ "${{ needs.test.result }}" == "failure" ]]; then
-            echo "failure=true" >> "$GITHUB_ENV"
-          fi
-          if [[ "${{ needs.test.result }}" == "success" ]]; then
-            echo "success=true" >> "$GITHUB_ENV"
-          fi
-
-      - name: Extract workflow link
-        run: |
-          workflow_path=$(echo "${{ github.workflow_ref }}" | sed -E 's|^.*/(\.github/workflows/[^@]+)@\S*$|\1|')
-          echo "workflow_link=https://github.com/${{ github.repository }}/blob/${{ github.sha }}/$workflow_path" >> "$GITHUB_ENV"
-
-      - name: Create or close issue
-        run: |
-          # Search for issues opened by this job.
-          matching_issues=$(gh issue list \
-            --state open \
-            --author '@me' \
-            --json 'number,title' \
-            --jq 'map(select(.title == "${{ env.title }}") | .number)')
-
-          # Handle the case of multiple matching issues, even though this
-          # shouldn't happen under normal circumstances.
-          if [[ $(jq length <<<"$matching_issues") -gt 1 ]]; then
-            echo "ERROR: Multiple matching issues found:" >&2
-            for issue in $(jq -r '.[]' <<<"$matching_issues"); do
-                echo "- https://github.com/${{ github.repository }}/issues/$issue" >&2
-            done
-            echo "This must be handled manually." >&2
-            exit 1
-          fi
-
-          existing_issue=$(jq -r '.[0] | values' <<<"$matching_issues")
-
-          if [[ "${{ env.failure }}" == "true" ]]; then
-            if  [[ -z "$existing_issue" ]]; then
-              echo "New failure detected. Creating issue..."
-              new_issue=$(gh issue create \
-                --title "${{ env.title }}" \
-                --body "$body")
-              echo "Created issue: $new_issue"
-            else
-              echo "Open issue already exists: https://github.com/${{ github.repository }}/issues/$existing_issue"
-            fi
-          fi
-
-          if [[ "${{ env.success }}" == "true" ]]; then
-            if [[ -n "$existing_issue" ]]; then
-              echo "Closing issue https://github.com/${{ github.repository }}/issues/$existing_issue"
-              gh issue close "$existing_issue" \
-                --comment "Workflow is successful as of https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-            else
-              echo "No open issue to be closed."
-            fi
-          fi
-
-        env:
-          body: |
-            Automatically created by the workflow [${{ github.workflow }}](${{ env.workflow_link }}) which indicated failure on [run ${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
-
-            See the workflow run for details and make changes as necessary.
-
-            This issue will be automatically closed upon the next successful run of the workflow.
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_REPO }}
+    uses: nextstrain/.github/.github/workflows/report-failure.yaml
+    with:
+      failure: ${{ needs.test.result == 'failure' }}
+      success: ${{ needs.test.result == 'success' }}
+      title: Installation failure
+    secrets:
+      token: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_REPO }}

--- a/.github/workflows/installation.yaml
+++ b/.github/workflows/installation.yaml
@@ -62,6 +62,11 @@ jobs:
             echo "success=true" >> "$GITHUB_ENV"
           fi
 
+      - name: Extract workflow link
+        run: |
+          workflow_path=$(echo "${{ github.workflow_ref }}" | sed -E 's|^.*/(\.github/workflows/[^@]+)@\S*$|\1|')
+          echo "workflow_link=https://github.com/${{ github.repository }}/blob/${{ github.sha }}/$workflow_path" >> "$GITHUB_ENV"
+
       - name: Create or close issue
         run: |
           # Search for issues opened by this job.
@@ -100,7 +105,7 @@ jobs:
             if [[ -n "$existing_issue" ]]; then
               echo "Closing issue https://github.com/${{ github.repository }}/issues/$existing_issue"
               gh issue close "$existing_issue" \
-                --comment "Installation is successful as of https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                --comment "Workflow is successful as of https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
             else
               echo "No open issue to be closed."
             fi
@@ -108,9 +113,9 @@ jobs:
 
         env:
           body: |
-            _Automatically created by [installation.yaml](https://github.com/${{ github.repository }}/blob/${{ github.sha }}/.github/workflows/installation.yaml)_
+            Automatically created by the workflow [${{ github.workflow }}](${{ env.workflow_link }}) which indicated failure on [run ${{ github.run_id }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
 
-            An installation check has failed: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            See the workflow run for details and make changes as necessary.
 
             This issue will be automatically closed upon the next successful run of the workflow.
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_REPO }}

--- a/.github/workflows/installation.yaml
+++ b/.github/workflows/installation.yaml
@@ -51,6 +51,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set variables
+        run: |
+          echo "title='Installation failure'" >> "$GITHUB_ENV"
+
+          if [[ "${{ needs.test.result }}" == "failure" ]]; then
+            echo "failure=true" >> "$GITHUB_ENV"
+          fi
+          if [[ "${{ needs.test.result }}" == "success" ]]; then
+            echo "success=true" >> "$GITHUB_ENV"
+          fi
+
       - name: Create or close issue
         run: |
           # Search for issues opened by this job.
@@ -73,11 +84,11 @@ jobs:
 
           existing_issue=$(jq -r '.[0] | values' <<<"$matching_issues")
 
-          if [[ "${{ needs.test.result }}" == "failure" ]]; then
+          if [[ "${{ env.failure }}" == "true" ]]; then
             if  [[ -z "$existing_issue" ]]; then
               echo "New failure detected. Creating issue..."
               new_issue=$(gh issue create \
-                --title "$title" \
+                --title "${{ env.title }}" \
                 --body "$body")
               echo "Created issue: $new_issue"
             else
@@ -85,7 +96,7 @@ jobs:
             fi
           fi
 
-          if [[ "${{ needs.test.result }}" == "success" ]]; then
+          if [[ "${{ env.success }}" == "true" ]]; then
             if [[ -n "$existing_issue" ]]; then
               echo "Closing issue https://github.com/${{ github.repository }}/issues/$existing_issue"
               gh issue close "$existing_issue" \
@@ -96,7 +107,6 @@ jobs:
           fi
 
         env:
-          title: Installation failure
           body: |
             _Automatically created by [installation.yaml](https://github.com/${{ github.repository }}/blob/${{ github.sha }}/.github/workflows/installation.yaml)_
 

--- a/.github/workflows/installation.yaml
+++ b/.github/workflows/installation.yaml
@@ -46,7 +46,8 @@ jobs:
   report-failure:
     if: ${{ always() && github.ref_name == github.event.repository.default_branch }}
     needs: [test]
-    uses: nextstrain/.github/.github/workflows/report-failure.yaml
+    # FIXME: drop the branch tag after merging https://github.com/nextstrain/.github/pull/121
+    uses: nextstrain/.github/.github/workflows/report-failure.yaml@victorlin/report-failure
     with:
       failure: ${{ needs.test.result == 'failure' }}
       success: ${{ needs.test.result == 'success' }}


### PR DESCRIPTION
## Description of proposed changes

Making this usable by other repos.

## Related issue(s)

- https://github.com/nextstrain/.github/issues/136

## Checklist

- [ ] Checks pass
- [x] [Installation failure = issue created](https://github.com/victorlin/conda-base/actions/runs/13212457338/job/36887814756#step:4:55)
    - Preview: https://github.com/victorlin/conda-base/issues/17
- [x] [Installation failure with 1 open issue = no action](https://github.com/victorlin/conda-base/actions/runs/13212457338/job/36887825619#step:4:54)
- [x] [Installation success with 2 open issues = error](https://github.com/victorlin/conda-base/actions/runs/13212520857/job/36887925513#step:4:54)
- [x] [Installation success with 1 open issue = issue closed](https://github.com/victorlin/conda-base/actions/runs/13212520857/job/36887846160#step:4:55)
- [x] [Installation success with no open issue = no action](https://github.com/victorlin/conda-base/actions/runs/13212520857/job/36887891614#step:4:54)
- [ ] Merge https://github.com/nextstrain/.github/pull/121
- [ ] Drop a4c8ddaa6b3b6c8c9e0b9706a208f0bb015025d8
