### PR TITLE
.github/workflows/installation: Update ubuntu runners

### DIFF
--- a/.github/workflows/installation.yaml
+++ b/.github/workflows/installation.yaml
@@ -25,8 +25,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
           - ubuntu-22.04
+          - ubuntu-24.04
           - macos-13
           - macos-14
           - macos-15


### PR DESCRIPTION
## Description of proposed changes

Remove ubuntu-20.04 since GH Actions has officially ended support for it on 2025-04-15. Add ubuntu-24.04 since it has been available for a while.

<https://github.com/actions/runner-images/issues/11101>

## Related issue(s)

Following up to https://github.com/nextstrain/.github/issues/122#issuecomment-2651855979

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
