### PR TITLE
Resolve hanging build for ubuntu-22.04 and macos-13

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,7 @@ jobs:
         run: |
           curl -fsSL --proto 'https=' https://micro.mamba.pm/install.sh | bash
           echo ~/.local/bin >> "$GITHUB_PATH"
+      - run: micromamba --version
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,6 +161,7 @@ jobs:
       env: |
         NEXTSTRAIN_CONDA_CHANNEL: nextstrain/label/${{ needs.generate-version.outputs.label }}
         NEXTSTRAIN_CONDA_BASE_PACKAGE: nextstrain-base ==${{ needs.generate-version.outputs.version }}
+        NEXTSTRAIN_CONDA_MICROMAMBA_VERSION: 2.1.0
       artifact-name: ${{ matrix.pathogen }}-outputs
       continue-on-error: true
 
@@ -196,5 +197,6 @@ jobs:
       env: |
         NEXTSTRAIN_CONDA_CHANNEL: nextstrain/label/${{ needs.generate-version.outputs.label }}
         NEXTSTRAIN_CONDA_BASE_PACKAGE: nextstrain-base ==${{ needs.generate-version.outputs.version }}
+        NEXTSTRAIN_CONDA_MICROMAMBA_VERSION: 2.1.0
       artifact-name: ${{ matrix.pathogen }}-outputs
       continue-on-error: true

--- a/devel/build
+++ b/devel/build
@@ -49,6 +49,9 @@ lock() {
     # somehow or leverage libmamba directly to obtain it…
     #   -14 Oct 2022
     log "Updating $repo/locked/recipe.yaml"
+    # Filtering out the "_x86_64-microarch-level" dependency as it causes
+    # errors when installing with micromamba
+    # See <https://github.com/nextstrain/conda-base/issues/105>
     yq \
         --yaml-roundtrip \
         --slurpfile rendered <(rendered-recipe | yaml-to-json) \
@@ -57,7 +60,8 @@ lock() {
             | .build.string = $rendered[0].build.string + "_locked"
             | .requirements.run = (
                   $rendered[0].requirements.run
-                | map(split(" ") | "\(.[0]) ==\(.[1]) \(.[2])"))
+                | map(select(. | startswith("_x86_64-microarch-level") | not)
+                    | split(" ") | "\(.[0]) ==\(.[1]) \(.[2])"))
         ' \
         < src/recipe.yaml \
         > locked/recipe.yaml

--- a/src/recipe.yaml
+++ b/src/recipe.yaml
@@ -60,7 +60,7 @@ requirements:
     # systems with an older bash.  This is similar to how our Docker runtime
     # image includes its own bash too.
     #
-    - awscli
+    - awscli >=2
     - bash
     - bzip2
     - csvtk


### PR DESCRIPTION
## Description of proposed changes

_Depends on the merge and release of https://github.com/nextstrain/cli/pull/430_

I'm still not entirely sure _why_ the build was hanging, but this seems to resolve the issue:

- pin `awscli >=2`
- filter out `_x86_64-microarch-level` from locked/recipe.yaml to work around installation error on ubuntu-22.04

## Related issue(s)

Resolves https://github.com/nextstrain/conda-base/issues/105

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
