### PR TITLE
Resolve hanging build for ubuntu-22.04 and macos-13 (without Micromamba bump)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,7 @@ jobs:
         run: |
           curl -fsSL --proto 'https=' https://micro.mamba.pm/install.sh | bash
           echo ~/.local/bin >> "$GITHUB_PATH"
+      - run: micromamba --version
 
       - uses: actions/checkout@v4
 

--- a/devel/build
+++ b/devel/build
@@ -15,6 +15,23 @@ main() {
     CONDA_SUBDIR="${CONDA_SUBDIR:-$(./devel/conda-subdir)}"
     export CONDA_SUBDIR
 
+    # Set CONDA_OVERRIDE_ARCHSPEC if it's unset or empty.
+    if [[ -z "${CONDA_OVERRIDE_ARCHSPEC:-}" ]]; then
+        # Unset CONDA_OVERRIDE_ARCHSPEC if it's set but empty.  An empty
+        # archspec override *omits* the virtual __archspec package from
+        # solving, and we don't want to do that.
+        unset CONDA_OVERRIDE_ARCHSPEC
+
+        case "$CONDA_SUBDIR" in
+            linux-64|osx-64)
+                # Avoid x86_64-microarch-level versions >1 for greatest
+                # compatibility
+                export CONDA_OVERRIDE_ARCHSPEC=x86_64;;
+
+            # Other subdirs use their default.
+        esac
+    fi
+
     clean
     build src
     lock

--- a/src/recipe.yaml
+++ b/src/recipe.yaml
@@ -60,7 +60,7 @@ requirements:
     # systems with an older bash.  This is similar to how our Docker runtime
     # image includes its own bash too.
     #
-    - awscli
+    - awscli >=2
     - bash
     - bzip2
     - csvtk


### PR DESCRIPTION
## Description of proposed changes

This is an alternative to https://github.com/nextstrain/conda-base/pull/108 that does _not_ require bumping the version for Micromamba in the Nextstrain CLI.

- pin `awscli >=2`
- pin to `_x86_64-microarch-level ==1` with `CONDA_OVERRIDE_ARCHSPEC=x86_64`


## Related issue(s)

Resolves https://github.com/nextstrain/conda-base/issues/105

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
