### PR TITLE
dev: Pass arguments to ./devel/build thru to the package builder

### DIFF
--- a/devel/build
+++ b/devel/build
@@ -33,9 +33,9 @@ main() {
     fi
 
     clean
-    build src
+    build src "$@"
     lock
-    build locked
+    build locked "$@"
 }
 
 clean() {


### PR DESCRIPTION
Helpful in local development for adjusting builder options.  The build() function here already expected to receive and pass thru extra arguments but main() wasn't doing its part.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
