### PR TITLE
dev: Use rattler-build instead of boa-build

### DIFF
--- a/.condarc
+++ b/.condarc
@@ -1,4 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda
-channel_priority: strict

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ unsuitable for use in a user-managed Conda environment.
 
 ## How it works
 
-The meta-package source recipe is in `src/recipe.yaml`.  This is a [Boa recipe
-spec](https://boa-build.readthedocs.io/en/latest/recipe_spec.html).  It defines
-our runtime's direct dependencies, typically without version restrictions
-(pins) or with only loose pinning as necessary.
+The meta-package source recipe is in `src/recipe.yaml`.  This is a
+[rattler-build recipe spec][].  It defines our runtime's direct dependencies,
+typically without version restrictions (pins) or with only loose pinning as
+necessary.
 
 A two-pass build process is used to produce the final package.
 
@@ -41,6 +41,8 @@ As the fully locked dependency trees are platform-specific, [CI][] produces
 packages for both Linux and macOS (i.e. for Conda's `linux-64` and `osx-64`
 subdirs).
 
+[rattler-build recipe spec]: https://rattler.build/latest/reference/recipe_file/
+
 
 ## Developing
 
@@ -49,7 +51,7 @@ production releases to happen via CI so packages are built for both Linux and
 macOS._
 
 First, setup a Conda environment for development in `.dev-env/` so that
-[Boa](https://boa-build.readthedocs.io) is available.
+[rattler-build](https://rattler.build) is available.
 
     ./devel/setup
 
@@ -134,8 +136,6 @@ overwritten on each build and not tracked in version control.
 `build/` contains build outputs not tracked in version control.
 
 `devel/` contains programs for development of this package.
-
-`.condarc` is used to specify configuration (e.g. channels) for `boa build`.
 
 
 ## History

--- a/devel/build
+++ b/devel/build
@@ -49,43 +49,49 @@ build() {
 
     log "Building $repo/$recipe_dir into $repo/build/$recipe_dir"
 
-    # Boa's configuration framework is not quite fully-baked: it's only minimally
-    # configurable with env vars and reads only ~/.condarc, no other RC files.  Lie
-    # about HOME so we can configure channels properly for the build.
-    HOME="$repo" boa build --pkg-format 2 --croot "./build/$recipe_dir" "$recipe_dir" "$@"
+    rattler-build build \
+        --channel conda-forge \
+        --channel bioconda \
+        --channel-priority strict \
+        --package-format conda:22 \
+        --output-dir "./build/$recipe_dir" \
+        --recipe "$recipe_dir" \
+        "$@"
 }
 
 lock() {
     log "Copying $repo/src to $repo/locked"
     cp -a src locked
 
-    # XXX TODO: It would be extra nice to prepend channel specifiers to each
-    # locked dep (e.g. conda-forge::nextstrain-cli ==x.y.z hbadcafe_0_locked).
-    # Boa has that info at build time, but it doesn't seem to make it into the
-    # rendered recipe included in the package.  Would have to reach into Boa
-    # somehow or leverage libmamba directly to obtain it…
-    #   -14 Oct 2022
     log "Updating $repo/locked/recipe.yaml"
     yq \
         --yaml-roundtrip \
         --slurpfile rendered <(rendered-recipe | yaml-to-json) \
         '
-              .package.version = $rendered[0].package.version
-            | .build.string = $rendered[0].build.string + "_locked"
+              .package.version = $rendered[0].recipe.package.version
+            | .build.string = $rendered[0].recipe.build.string + "_locked"
+            | .requirements.build = []
+            | .requirements.host = []
             | .requirements.run = (
-                  $rendered[0].requirements.run
-                | map(split(" ") | "\(.[0]) ==\(.[1]) \(.[2])"))
+                  $rendered[0].finalized_dependencies.host.resolved
+                | map("\(.channel)::\(.name) ==\(.version) \(.build)"))
         ' \
         < src/recipe.yaml \
         > locked/recipe.yaml
 }
 
 rendered-recipe() {
-    # It would be really nice if we could use `boa render` (or `conda render`)
-    # for this, but we can't seem to.  Instead, extract the rendered recipe
-    # from the package built in the first pass.
+    # It would be really nice if we could use `rattler-build build
+    # --render-only --with-solve` (or `conda render`) for this, but we can't
+    # seem to.  Instead, extract the rendered recipe from the package built in
+    # the first pass.
+    #
+    # Note that rattler-build doesn't guarantee the format of this rendered
+    # recipe¹, so we might hit breakage in the future.
+    #
+    # ¹ <https://rattler.build/latest/package_spec/#inforecipe>
     local package="$(echo ./build/src/*/nextstrain-base-"$VERSION"-!(*_locked).conda)"
-    ./devel/extract-pkg-info "$package" recipe/recipe.yaml
+    ./devel/extract-pkg-info "$package" recipe/rendered_recipe.yaml
 }
 
 yaml-to-json() {

--- a/devel/setup
+++ b/devel/setup
@@ -19,7 +19,7 @@ remove() {
 create() {
     local -a pkgs=(
         "anaconda-client>=1.12.0"
-        "boa>=0.16.0"
+        rattler-build
 
         # for manipulating recipe.yaml with jq
         yq
@@ -36,10 +36,6 @@ create() {
         csv-diff
         curl
         wget
-
-        # Temporary pin until boa fixes dependency upstream
-        # <https://github.com/mamba-org/boa/issues/388>
-        "conda-build<3.28.0"
     )
 
     log "Creating new env with packages: ${pkgs[*]}"

--- a/src/LICENSE
+++ b/src/LICENSE
@@ -1,0 +1,1 @@
+The license for this meta-package is MIT; individual tools vary.

--- a/src/recipe.yaml
+++ b/src/recipe.yaml
@@ -1,38 +1,38 @@
 package:
   name: nextstrain-base
-  version: "{{ environ['VERSION'] }}"
+  version: ${{ env.get("VERSION") }}
 
 build:
   number: 0
-  #
-  # XXX TODO: If Boa ever supports conda-build's "pin_depends: strict" here¹, I
-  # think it could replace our entire two-pass build process!  Unfortunately,
-  # conda-build is so much slower than Boa that the more complicated build
-  # process is worth it.
-  #   -trs, 14 Oct 2022
-  #
-  # ¹ <https://github.com/mamba-org/boa/issues/300>
-  #
-  #pin_depends: strict
+
+  # If we were using conda-build, we'd use "pin_depends: strict" here and
+  # replace our entire two-pass build process!  But using rattler-build lets us
+  # get even more specific pinnings (e.g. with channels) and a bit more control
+  # over the build process.  It's output is also a fair bit easier to read.
+  #   -trs, 8 May 2025
 
 source:
   path: .
 
 about:
-  home: https://nextstrain.org
-  doc_url: https://docs.nextstrain.org/
-  dev_url: https://github.com/nextstrain/conda-base
+  homepage: https://nextstrain.org
+  documentation: https://docs.nextstrain.org/
+  repository: https://github.com/nextstrain/conda-base
   summary: Base Nextstrain runtime (meta-package)
   description: >
     This meta-package depends on all the other packages needed for a base
     Nextstrain runtime installed as a Conda environment.  As the
     nextstrain/base image is to Nextstrain CLI's Docker runtime, this
     nextstrain-base package is to Nextstrain CLI's Conda runtime.
-  license: >
-    The license for this meta-package is MIT; individual tools vary.
 
 requirements:
-  run:
+  # Declare "host" requirements (i.e. build requirements for the target arch)
+  # instead of "run" requirements because rattler-build's rendered recipe only
+  # includes the full solve for build and host requirements and not run
+  # requirements.  In devel/build, we move the resolved host requirements into
+  # the package's run requirements.
+  #   -trs, 8 May 2025
+  host:
     #
     # First-party
     #


### PR DESCRIPTION
Boa is superseded by rattler-build.¹  Otherwise, they're very similar.

As an alternative, we could start using conda-build instead now that it uses libsolv and move to a one-pass build process, but there are some advantages² (though maybe minor?) to sticking with rattler-build and our two pass build process.

¹ <https://github.com/mamba-org/boa/commit/034f2e1cc0d31f962a52aaa153ac64b856127f8c>
  <https://rattler.build>

² Such as including the channel in the locked deps.

Resolves: <https://github.com/nextstrain/conda-base/issues/68>
Alternatively: <https://github.com/nextstrain/conda-base/pull/114>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
