### PR TITLE
dev: Use conda-build instead of boa-build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,13 +67,12 @@ jobs:
           name: build-outputs-${{ matrix.os }}
           path: |
             build/
-            locked/
 
       - if: always()
         uses: actions/upload-artifact@v4
         with:
           name: packages-${{ matrix.os }}
-          path: build/locked/*/nextstrain-base-*.conda
+          path: build/*/nextstrain-base-*.conda
 
       - name: Test install of nextstrain-base
         run: |
@@ -82,7 +81,7 @@ jobs:
             --prefix ./test-env             \
             --strict-channel-priority       \
             --override-channels             \
-            --channel ./build/locked        \
+            --channel ./build/              \
             --channel conda-forge           \
             --channel bioconda              \
             nextstrain-base
@@ -91,7 +90,7 @@ jobs:
         continue-on-error: true
         run: |
           ./devel/download-latest
-          ./devel/diff-pkgs nextstrain-base-*.conda build/locked/*/nextstrain-base-*.conda \
+          ./devel/diff-pkgs nextstrain-base-*.conda build/*/nextstrain-base-*.conda \
             > "$GITHUB_STEP_SUMMARY"
 
   release:
@@ -113,7 +112,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: packages
-          path: build/locked/
+          path: build/
 
       - run: ./devel/setup
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 
 # Build outputs
 /build/
-/locked/

--- a/devel/build
+++ b/devel/build
@@ -34,62 +34,26 @@ main() {
 
     clean
     build src "$@"
-    lock
-    build locked "$@"
 }
 
 clean() {
-    log "Removing $repo/build and $repo/locked"
-    rm -rf ./build ./locked
+    log "Removing $repo/build"
+    rm -rf ./build
 }
 
 build() {
     local recipe_dir="$1"
     shift
 
-    log "Building $repo/$recipe_dir into $repo/build/$recipe_dir"
+    log "Building $repo/$recipe_dir into $repo/build"
 
-    # Boa's configuration framework is not quite fully-baked: it's only minimally
-    # configurable with env vars and reads only ~/.condarc, no other RC files.  Lie
-    # about HOME so we can configure channels properly for the build.
-    HOME="$repo" boa build --pkg-format 2 --croot "./build/$recipe_dir" "$recipe_dir" "$@"
-}
-
-lock() {
-    log "Copying $repo/src to $repo/locked"
-    cp -a src locked
-
-    # XXX TODO: It would be extra nice to prepend channel specifiers to each
-    # locked dep (e.g. conda-forge::nextstrain-cli ==x.y.z hbadcafe_0_locked).
-    # Boa has that info at build time, but it doesn't seem to make it into the
-    # rendered recipe included in the package.  Would have to reach into Boa
-    # somehow or leverage libmamba directly to obtain it…
-    #   -14 Oct 2022
-    log "Updating $repo/locked/recipe.yaml"
-    yq \
-        --yaml-roundtrip \
-        --slurpfile rendered <(rendered-recipe | yaml-to-json) \
-        '
-              .package.version = $rendered[0].package.version
-            | .build.string = $rendered[0].build.string + "_locked"
-            | .requirements.run = (
-                  $rendered[0].requirements.run
-                | map(split(" ") | "\(.[0]) ==\(.[1]) \(.[2])"))
-        ' \
-        < src/recipe.yaml \
-        > locked/recipe.yaml
-}
-
-rendered-recipe() {
-    # It would be really nice if we could use `boa render` (or `conda render`)
-    # for this, but we can't seem to.  Instead, extract the rendered recipe
-    # from the package built in the first pass.
-    local package="$(echo ./build/src/*/nextstrain-base-"$VERSION"-!(*_locked).conda)"
-    ./devel/extract-pkg-info "$package" recipe/recipe.yaml
-}
-
-yaml-to-json() {
-    yq '.'
+    # Lie about HOME so we can configure channels properly for the build via
+    # .condarc and isolate ourselves from the user's own .condarc.
+    HOME="$repo" conda build \
+       --package-format conda \
+       --croot ./build \
+       "$recipe_dir" \
+       "$@"
 }
 
 main "$@"

--- a/devel/extract-pkg-info
+++ b/devel/extract-pkg-info
@@ -6,7 +6,7 @@
 #
 # Example:
 #
-#     ./devel/extract-pkg-info build/locked/*/nextstrain-base-*.conda recipe/recipe.yaml
+#     ./devel/extract-pkg-info build/*/nextstrain-base-*.conda recipe/recipe.yaml
 #
 set -euo pipefail
 

--- a/devel/setup
+++ b/devel/setup
@@ -19,10 +19,7 @@ remove() {
 create() {
     local -a pkgs=(
         "anaconda-client>=1.12.0"
-        "boa>=0.16.0"
-
-        # for manipulating recipe.yaml with jq
-        yq
+        conda-build
 
         # for extracting files from .conda packages
         p7zip
@@ -36,10 +33,6 @@ create() {
         csv-diff
         curl
         wget
-
-        # Temporary pin until boa fixes dependency upstream
-        # <https://github.com/mamba-org/boa/issues/388>
-        "conda-build<3.28.0"
     )
 
     log "Creating new env with packages: ${pkgs[*]}"

--- a/devel/upload
+++ b/devel/upload
@@ -11,7 +11,7 @@ main() {
         --token "$ANACONDA_TOKEN" \
         upload \
             --label "${LABEL:-$(./devel/label-for-ref)}" \
-            ./build/locked/*/nextstrain-base-*_locked.conda
+            ./build/*/nextstrain-base-*.conda
 }
 
 main "$@"

--- a/src/meta.yaml
+++ b/src/meta.yaml
@@ -4,16 +4,7 @@ package:
 
 build:
   number: 0
-  #
-  # XXX TODO: If Boa ever supports conda-build's "pin_depends: strict" here¹, I
-  # think it could replace our entire two-pass build process!  Unfortunately,
-  # conda-build is so much slower than Boa that the more complicated build
-  # process is worth it.
-  #   -trs, 14 Oct 2022
-  #
-  # ¹ <https://github.com/mamba-org/boa/issues/300>
-  #
-  #pin_depends: strict
+  pin_depends: strict
 
 source:
   path: .


### PR DESCRIPTION
conda-build became a reasonable choice ever since Conda switched to libsolv for dependency resolution (i.e. the same solver used by Mamba/Boa).  The big upside to using conda-build is that our recipe can declare:

  build:
    pin_depends: strict

and ditch our entire two-pass build process! \o/

Resolves: <https://github.com/nextstrain/conda-base/issues/68>
Alternatively: <https://github.com/nextstrain/conda-base/pull/113>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
