### PR TITLE
Pin ncbi-datasets-cli to the last working version (18.0.2) on macOS arm64

### DIFF
--- a/src/meta.yaml
+++ b/src/meta.yaml
@@ -67,6 +67,11 @@ requirements:
     - iqtree >=2
     - jq
     - ncbi-datasets-cli
+
+    # XXX TODO: Remove when <https://github.com/ncbi/datasets/issues/490> is resolved.
+    #   -trs, 20 May 2025
+    - ncbi-datasets-cli 18.0.2 # [osx and arm64]
+
     - pango_aliasor
     - perl
       # Pin pulp <2.8 for snakemake: https://github.com/snakemake/snakemake/issues/2607


### PR DESCRIPTION
Newer versions (18.0.5…18.2.0) inexplicably hang.  See troubleshooting and conversation in Slack¹ and our open issue with upstream.²

¹ <https://bedfordlab.slack.com/archives/C7SDVPBLZ/p1747770652419989?thread_ts=1747766690.155149&cid=C7SDVPBLZ> ² <https://github.com/ncbi/datasets/issues/490>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
