### PR TITLE
dev: Report `conda info` during devel/build for logs

### DIFF
--- a/devel/build
+++ b/devel/build
@@ -41,8 +41,20 @@ main() {
         esac
     fi
 
+    info
     clean
     build src "$@"
+}
+
+conda_() {
+    # Lie about HOME so we can configure channels properly for the build via
+    # .condarc and isolate ourselves from the user's own .condarc.
+    HOME="$repo" conda "$@"
+}
+
+info() {
+    log 'Reporting `conda info` for logs'
+    conda_ info
 }
 
 clean() {
@@ -56,9 +68,7 @@ build() {
 
     log "Building $repo/$recipe_dir into $repo/build"
 
-    # Lie about HOME so we can configure channels properly for the build via
-    # .condarc and isolate ourselves from the user's own .condarc.
-    HOME="$repo" conda build \
+    conda_ build \
        --package-format conda \
        --croot ./build \
        "$recipe_dir" \


### PR DESCRIPTION
It's often useful to see what paths and channels and virtual package specs are in use when debugging a build.

Motivated by @joverlee521's comment¹ in another PR that the virtual packages in use weren't directly visible.

¹ <https://github.com/nextstrain/conda-base/pull/123#pullrequestreview-3102268682>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
