### PR TITLE
Remove ebola repo check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -144,7 +144,6 @@ jobs:
       matrix:
         include:
           - { pathogen: avian-flu,       build-args: --snakefile segment-focused/Snakefile -pf test_target }
-          - { pathogen: ebola }
           - { pathogen: ncov,            build-args: all_regions -j 2 --profile nextstrain_profiles/nextstrain-ci }
           - { pathogen: rsv }
           - { pathogen: seasonal-flu,    build-args: --configfile profiles/ci/builds.yaml -p }


### PR DESCRIPTION
## Description of proposed changes

This repo has been reworked to be compatible with the newer pathogen-repo-ci and thus no longer works with pathogen-repo-ci-v0.

I chose not to check the new version because it is still in progress. The only check would be on an [unstable](https://github.com/nextstrain/ebola/issues/20) and [long-running](https://github.com/nextstrain/ebola/pull/15#issuecomment-3286017943) ingest workflow, which doesn't seem useful to include here as-is.

## Related issue(s)

Follow-up to https://github.com/nextstrain/ebola/pull/16#pullrequestreview-3218960692

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] ~Update changelog~ N/A

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
