### PR TITLE
Use macOS 15 Intel runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,8 +42,8 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
-          - macos-13 # x86_64
-          - macos-14 # arm64
+          - macos-15-intel # x86_64
+          - macos-14       # arm64
 
     name: build and test (os=${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/installation.yaml
+++ b/.github/workflows/installation.yaml
@@ -27,7 +27,7 @@ jobs:
         os:
           - ubuntu-22.04
           - ubuntu-24.04
-          - macos-13
+          - macos-15-intel
           - macos-14
           - macos-15
 


### PR DESCRIPTION
## Description of proposed changes

macOS 13 runners are being deprecated. Replace them with another x86_64 (Intel) runner to continue building and testing for that architecture.

## Related issue(s)

https://github.com/nextstrain/.github/issues/150

## Checklist

- [x] Checks pass
