### PR TITLE
CI: Sync pathogen repo list

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -178,10 +178,13 @@ jobs:
           - measles
           - mpox
           - mumps
+          - nipah
+          - norovirus
           - oropouche
           - rabies
+          - rubella
           - seasonal-cov
-          - wnv
+          - WNV
           - yellow-fever
           - zika
 


### PR DESCRIPTION
Generated programmatically using:

    gh api --paginate "search/code?q=org:nextstrain+-repo:nextstrain/pathogen-repo-guide+path:phylogenetic/build-configs/ci+filename:config.yaml" | \
    jq -r '.items[] | "          - \(.repository.name)"' | \
    sort -f

Motivated by https://github.com/nextstrain/nipah/issues/22

## Checklist

- [x] Checks pass
