### PR TITLE
Exclude snakemake-interface-storage-plugins 4.4.0

### DIFF
--- a/src/meta.yaml
+++ b/src/meta.yaml
@@ -72,6 +72,7 @@ requirements:
     - sed
     - seqkit
     - snakemake =9.6.2
+    - snakemake-interface-storage-plugins !=4.4.0  # TODO: remove after merge of https://github.com/bioconda/bioconda-recipes/pull/63553
     - snakemake-storage-plugin-http
     - snakemake-storage-plugin-s3
     - sqlite


### PR DESCRIPTION
The only available build for this version does not declare a run time dependency on tenacity.

Upstream PR: https://github.com/bioconda/bioconda-recipes/pull/63553

[Slack context](https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1773682706013319)

## Checklist

- [x] Checks pass
