### PR TITLE
Revert snakemake-interface-storage-plugins pin

### DIFF
--- a/src/meta.yaml
+++ b/src/meta.yaml
@@ -72,7 +72,6 @@ requirements:
     - sed
     - seqkit
     - snakemake =9.6.2
-    - snakemake-interface-storage-plugins !=4.4.0  # TODO: remove after merge of https://github.com/bioconda/bioconda-recipes/pull/63553
     - snakemake-storage-plugin-http
     - snakemake-storage-plugin-s3
     - sqlite


### PR DESCRIPTION
This reverts #145. The upstream fix has been merged and a new build is available.

## Checklist

- [x] Checks pass