### PR TITLE
Update Snakemake pin

### DIFF
--- a/src/meta.yaml
+++ b/src/meta.yaml
@@ -71,7 +71,7 @@ requirements:
     - ruby
     - sed
     - seqkit
-    - snakemake <9.17.0
+    - snakemake
     - snakemake-storage-plugin-http
     - snakemake-storage-plugin-s3
     - sqlite

--- a/src/meta.yaml
+++ b/src/meta.yaml
@@ -71,7 +71,7 @@ requirements:
     - ruby
     - sed
     - seqkit
-    - snakemake =9.6.2
+    - snakemake <9.17.0
     - snakemake-storage-plugin-http
     - snakemake-storage-plugin-s3
     - sqlite


### PR DESCRIPTION
The pin was originally added in "Pin Snakemake to v9.6.2" (1e35b6ae) due to downstream incompatibilities with Snakemake v9.16.3. Those have since been resolved, but there are new incompatibilities with v9.17.0 caught by CI on GitHub Actions.

Related to https://github.com/nextstrain/public/issues/37

## Checklist

- [x] Checks pass
