### PR TITLE
Replace zstd with zstandard

### DIFF
--- a/src/meta.yaml
+++ b/src/meta.yaml
@@ -82,4 +82,4 @@ requirements:
     - xlrd
     - xz
     - zip
-    - zstd
+    - zstandard


### PR DESCRIPTION
## Description of proposed changes

zstandard used to be an indirect dependency of Augur, until xopen removed it and we pivoted to the stdlib/backport in
<https://github.com/nextstrain/augur/pull/2009>

Adding here to not disrupt use by pathogen builds similar to docker-base.¹ Since zstandard is dependent on zstd, this switch should be fine.²

¹ <https://github.com/nextstrain/docker-base/pull/286> 
² <https://github.com/conda-forge/zstandard-feedstock/blob/38229990240cc2592d2e507381afac99a434d7f6/recipe/recipe.yaml#L40>


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] ~Update changelog~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
